### PR TITLE
Fix/startup

### DIFF
--- a/DFW.cpp
+++ b/DFW.cpp
@@ -57,7 +57,7 @@ void DFW::update(void)
 	digitalWrite(debuginpin,0);
       lastTime = millis();
       //   Serial.println("B Lock");
-      for (int i = 0; i < 3; i++)  {
+      for (int i = 0; i < 5; i++)  {
         byteBu[i] = inByteB[i];
       }
     }

--- a/DFW.h
+++ b/DFW.h
@@ -2,7 +2,7 @@
 //written by Joe St. Germain
 //For RBE Class use
 //joest@wpi.edu
-
+//@author Alex Taglieri (atags22)
 
 #ifndef DFW_h
 #define DFW_h


### PR DESCRIPTION
There was a problem before where, when the robot first turns on, the
back left wheel turns at full power until the joystick connects. I
believe the root cause of the issue is that the array of joystick values
doesn't correctly reset the value of Joystick Left Vertical. This
revision fixes that issue hopefully.